### PR TITLE
Handle multiple servers, channels and announcers in the tracker XML files

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -41,28 +41,31 @@ url = http://localhost:8686
 # Any periods (.) in "type" shall be replaced with underscore (_) as the config
 # implementation uses periods to denote subsections.
 [x264]
-# IRC nickname
 # Mandatory
 irc_nickname = arrnounced_bot
-
-# IRC port
+irc_server = example.com
 irc_port = 6667
+
+# IRC channels to join. If irc_invite_cmd is set the channels will not be
+# joined until an invite to a channel is received.
+# Mandatory
+irc_channels = #x264, #example_channel
 
 # Password for registration with IRC NICKSERV.
 # Default empty
 irc_ident_password = password
-#
+
+# Connect to IRC using TLS (Transport Layer Security)
+irc_tls = false
+# Verify TLS certificate. False means connect even if not valid.
+irc_tls_verify = false
+
 # Fields "irc_inviter" and "irc_invite_cmd" must be used together.
 # "irc_inviter" is the nickname the IRC channel invite request is sent to.
 # "irc_invite_cmd" is whatever you send to "irc_inviter" to request an invite.
 # Default empty
 irc_inviter = x2bot
 irc_invite_cmd = invite_me #x264
-
-# Connect to IRC using TLS (Transport Layer Security)
-irc_tls = false
-# Verify TLS certificate. False means connect even if not valid.
-irc_tls_verify = false
 
 # This is a special field which is specified in the XML tracker configuration
 # file, x265.tracker, under "settings". It is mandatory because it is needed
@@ -96,7 +99,9 @@ category_radarr = movie|film|motion picture
 # A seconds example tracker. This time slimmed down
 [nbl]
 irc_nickname = arrnounced_bot
+irc_server = example.com
 irc_port = 6697
+irc_channels = #example_channel2
 
 irc_ident_password = password
 

--- a/example.cfg
+++ b/example.cfg
@@ -41,28 +41,28 @@ url = http://localhost:8686
 # Any periods (.) in "type" shall be replaced with underscore (_) as the config
 # implementation uses periods to denote subsections.
 [x264]
-# IRC nick name
+# IRC nickname
 # Mandatory
-nick = arrnounced_bot
-
-# Password for registration with IRC NICKSERV.
-# Default empty
-nick_pass = nick_password
+irc_nickname = arrnounced_bot
 
 # IRC port
 irc_port = 6667
 
-# Connect to IRC using TLS (Transport Layer Security)
-tls = false
-# Verify TLS certificate. False means connect even if not valid.
-tls_verify = false
-
-# Fields "inviter" and "invite_cmd" must be used together.
-# "inviter" is the nickname the IRC channel invite request is sent to.
-# "invite_cmd" is whatever you send to "inviter" to request an invite.
+# Password for registration with IRC NICKSERV.
 # Default empty
-inviter = x2bot
-invite_cmd = invite_me #x264
+irc_ident_password = password
+#
+# Fields "irc_inviter" and "irc_invite_cmd" must be used together.
+# "irc_inviter" is the nickname the IRC channel invite request is sent to.
+# "irc_invite_cmd" is whatever you send to "irc_inviter" to request an invite.
+# Default empty
+irc_inviter = x2bot
+irc_invite_cmd = invite_me #x264
+
+# Connect to IRC using TLS (Transport Layer Security)
+irc_tls = false
+# Verify TLS certificate. False means connect even if not valid.
+irc_tls_verify = false
 
 # This is a special field which is specified in the XML tracker configuration
 # file, x265.tracker, under "settings". It is mandatory because it is needed
@@ -72,7 +72,7 @@ passkey = mypasskey
 
 # Delay in seconds between when an IRC announcement is received and
 # the backends are notified of the release.
-delay = 0
+announce_delay = 0
 
 # notify_* fields are used to always notify backends of an announcmenet from this tracker.
 # Default false
@@ -95,9 +95,10 @@ category_radarr = movie|film|motion picture
 
 # A seconds example tracker. This time slimmed down
 [nbl]
-nick = arrnounced_bot
-nick_pass = nick_password
+irc_nickname = arrnounced_bot
 irc_port = 6697
+
+irc_ident_password = password
 
 # Tracker XML config settings. (Remove "gazelle_" and "cookie_")
 authkey = my_auth_key

--- a/src/config.py
+++ b/src/config.py
@@ -13,43 +13,43 @@ def init(config_path):
     cfg.read()
 
     # Settings
-    cfg.init('webui.host', '0.0.0.0')
-    cfg.init('webui.port', '3467')
-    cfg.init('webui.username', None, type=str)
-    cfg.init('webui.password', None, type=str)
+    cfg.init("webui.host", "0.0.0.0")
+    cfg.init("webui.port", "3467")
+    cfg.init("webui.username", None, type=str)
+    cfg.init("webui.password", None, type=str)
 
-    cfg.init('log.to_file', True)
-    cfg.init('log.to_console', True)
+    cfg.init("log.to_file", True)
+    cfg.init("log.to_console", True)
 
-    cfg.init('sonarr.apikey', None, type=str)
-    cfg.init('sonarr.url', 'http://localhost:8989')
+    cfg.init("sonarr.apikey", None, type=str)
+    cfg.init("sonarr.url", "http://localhost:8989")
 
-    cfg.init('radarr.apikey', None, type=str)
-    cfg.init('radarr.url', 'http://localhost:7878')
+    cfg.init("radarr.apikey", None, type=str)
+    cfg.init("radarr.url", "http://localhost:7878")
 
-    cfg.init('lidarr.apikey', None, type=str)
-    cfg.init('lidarr.url', 'http://localhost:8686')
+    cfg.init("lidarr.apikey", None, type=str)
+    cfg.init("lidarr.url", "http://localhost:8686")
 
     for section in cfg.sections():
         if section.name in base_sections:
             continue
         # Init mandatory tracker values
-        section.init('irc_nickname', None, type=str)
+        section.init("irc_nickname", None, type=str)
 
         # Init optional tracker values
-        section.init('irc_port', 6667)
-        section.init('irc_tls', False)
-        section.init('irc_tls_verify', False)
-        section.init('irc_ident_password', None, type=str)
-        section.init('irc_inviter', None, type=str)
-        section.init('irc_invite_cmd', None, type=str)
-        section.init('announce_delay', 0)
-        section.init('notify_sonarr', False)
-        section.init('notify_radarr', False)
-        section.init('notify_lidarr', False)
-        section.init('category_sonarr', None, type=str)
-        section.init('category_radarr', None, type=str)
-        section.init('category_lidarr', None, type=str)
+        section.init("irc_port", 6667)
+        section.init("irc_tls", False)
+        section.init("irc_tls_verify", False)
+        section.init("irc_ident_password", None, type=str)
+        section.init("irc_inviter", None, type=str)
+        section.init("irc_invite_cmd", None, type=str)
+        section.init("announce_delay", 0)
+        section.init("notify_sonarr", False)
+        section.init("notify_radarr", False)
+        section.init("notify_lidarr", False)
+        section.init("category_sonarr", None, type=str)
+        section.init("category_radarr", None, type=str)
+        section.init("category_lidarr", None, type=str)
 
     #for s in cfg.sections():
     #    print(s)
@@ -118,21 +118,21 @@ def sections():
     return cfg.sections()
 
 def webui_host():
-    return cfg['webui.host']
+    return cfg["webui.host"]
 
 def webui_port():
-    return cfg['webui.port']
+    return cfg["webui.port"]
 
 def login_required():
-    if cfg['webui.username'] is None:
+    if cfg["webui.username"] is None:
         return False
     else:
         return True
 
 def login(username, password):
-    if cfg['webui.username'] is None:
+    if cfg["webui.username"] is None:
         return True
-    elif (cfg['webui.username'] == username and
-            cfg['webui.password'] == password):
+    elif (cfg["webui.username"] == username and
+            cfg["webui.password"] == password):
         return True
     return False

--- a/src/config.py
+++ b/src/config.py
@@ -34,16 +34,16 @@ def init(config_path):
         if section.name in base_sections:
             continue
         # Init mandatory tracker values
-        section.init('nick', None, type=str)
+        section.init('irc_nickname', None, type=str)
 
         # Init optional tracker values
         section.init('irc_port', 6667)
-        section.init('tls', False)
-        section.init('tls_verify', False)
-        section.init('nick_pass', None, type=str)
-        section.init('inviter', None, type=str)
-        section.init('invite_cmd', None, type=str)
-        section.init('delay', 0)
+        section.init('irc_tls', False)
+        section.init('irc_tls_verify', False)
+        section.init('irc_ident_password', None, type=str)
+        section.init('irc_inviter', None, type=str)
+        section.init('irc_invite_cmd', None, type=str)
+        section.init('announce_delay', 0)
         section.init('notify_sonarr', False)
         section.init('notify_radarr', False)
         section.init('notify_lidarr', False)
@@ -51,12 +51,11 @@ def init(config_path):
         section.init('category_radarr', None, type=str)
         section.init('category_lidarr', None, type=str)
 
-
     #for s in cfg.sections():
     #    print(s)
     return cfg
 
-mandatory_tracker_fields = [ "nick" ]
+mandatory_tracker_fields = [ "irc_nickname" ]
 
 def validate_config():
     global cfg
@@ -82,8 +81,8 @@ def validate_config():
                 logger.error("%s: Must set '%s'", section.name, mandatory)
                 valid = False
 
-        if bool(section.get("inviter")) != bool(section.get("invite_cmd")):
-            logger.error("%s: Must set both 'inviter' and 'invite_cmd'", section.name)
+        if bool(section.get("irc_inviter")) != bool(section.get("irc_invite_cmd")):
+            logger.error("%s: Must set both 'irc_inviter' and 'irc_invite_cmd'", section.name)
             valid = False
 
         if ((section.get("notify_sonarr") or section.get("category_sonarr") is not None)

--- a/src/config.py
+++ b/src/config.py
@@ -35,9 +35,11 @@ def init(config_path):
             continue
         # Init mandatory tracker values
         section.init("irc_nickname", None, type=str)
+        section.init("irc_server", None, type=str)
+        section.init("irc_port", None, type=int)
+        section.init("irc_channels", None, type=str)
 
         # Init optional tracker values
-        section.init("irc_port", 6667)
         section.init("irc_tls", False)
         section.init("irc_tls_verify", False)
         section.init("irc_ident_password", None, type=str)
@@ -55,7 +57,7 @@ def init(config_path):
     #    print(s)
     return cfg
 
-mandatory_tracker_fields = [ "irc_nickname" ]
+mandatory_tracker_fields = [ "irc_nickname", "irc_server", "irc_port", "irc_channels" ]
 
 def validate_config():
     global cfg

--- a/src/irc.py
+++ b/src/irc.py
@@ -26,10 +26,11 @@ class IRC(BotBase):
     # Request channel invite or join channel
     async def attempt_join_channel(self):
         if self.tracker_config.irc_invite_cmd is None:
-            logger.info("Joining %s", self.tracker_config.irc_channel)
-            await self.join(self.tracker_config.irc_channel)
+            for channel in self.tracker_config.user_channels:
+                logger.info("Joining %s", channel)
+                await self.join(channel)
         else:
-            logger.info("Requesting invite to %s", self.tracker_config.irc_channel)
+            logger.info("%s: Requesting invite", self.tracker_config.short_name)
             await self.message(self.tracker_config.irc_inviter, self.tracker_config.irc_invite_cmd)
 
     async def on_connect(self):
@@ -58,11 +59,10 @@ class IRC(BotBase):
 
     async def on_invite(self, channel, by):
         logger.info("%s invited us to join %s", by, channel)
-        if channel == self.tracker_config.irc_channel:
-            await self.join(self.tracker_config.irc_channel)
+        if channel in self.tracker_config.irc_channels:
+            await self.join(channel)
         else:
-            # TODO: Make sure this works
-            logger.warning("%s is not in irc_channels list or specified in XML tracker configuration. Skipping join",
+            logger.warning("Skipping join. %s is not in irc_channels list or specified in XML tracker configuration.",
                     channel)
 
 
@@ -76,7 +76,7 @@ def start(tracker_configs):
 
     for tracker_config in tracker_configs.values():
         logger.info("Connecting to server: %s:%d %s", tracker_config.irc_server,
-                tracker_config.irc_port, tracker_config.irc_channel)
+                tracker_config.irc_port, ", ".join(tracker_config.user_channels))
 
         client = IRC(tracker_config)
 

--- a/src/irc.py
+++ b/src/irc.py
@@ -57,9 +57,14 @@ class IRC(BotBase):
         await message_handler.on_message(self.tracker_config, source, target.lower(), message)
 
     async def on_invite(self, channel, by):
+        logger.info("%s invited us to join %s", by, channel)
         if channel == self.tracker_config.irc_channel:
             await self.join(self.tracker_config.irc_channel)
-            logger.info("%s invited us to join %s", by, channel)
+        else:
+            # TODO: Make sure this works
+            logger.warning("%s is not in irc_channels list or specified in XML tracker configuration. Skipping join",
+                    channel)
+
 
 
 pool = pydle.ClientPool()

--- a/src/irc.py
+++ b/src/irc.py
@@ -14,7 +14,7 @@ class IRC(BotBase):
     RECONNECT_MAX_ATTEMPTS = None
 
     def __init__(self, tracker_config):
-        super().__init__(tracker_config.irc_nick)
+        super().__init__(tracker_config.irc_nickname)
         self.tracker_config = tracker_config
 
     async def connect(self, *args, **kwargs):
@@ -25,22 +25,22 @@ class IRC(BotBase):
 
     # Request channel invite or join channel
     async def attempt_join_channel(self):
-        if self.tracker_config.invite_cmd is None:
+        if self.tracker_config.irc_invite_cmd is None:
             logger.info("Joining %s", self.tracker_config.irc_channel)
             await self.join(self.tracker_config.irc_channel)
         else:
             logger.info("Requesting invite to %s", self.tracker_config.irc_channel)
-            await self.message(self.tracker_config.inviter, self.tracker_config.invite_cmd)
+            await self.message(self.tracker_config.irc_inviter, self.tracker_config.irc_invite_cmd)
 
     async def on_connect(self):
         logger.info("Connected to: %s", self.tracker_config.irc_server)
         await super().on_connect()
 
-        if self.tracker_config.nick_pass is None:
+        if self.tracker_config.irc_ident_password is None:
             await self.attempt_join_channel()
         else:
             logger.info("Identifying with NICKSERV")
-            await self.rawmsg('NICKSERV', 'IDENTIFY', self.tracker_config.nick_pass)
+            await self.rawmsg('NICKSERV', 'IDENTIFY', self.tracker_config.irc_ident_password)
 
     async def on_raw(self, message):
         await super().on_raw(message)

--- a/src/message_handler.py
+++ b/src/message_handler.py
@@ -40,10 +40,10 @@ async def on_message(tracker_config, source, target, message):
     # If backends is empty backends_string is "None"
     backends_string = backends_to_string(backends)
 
-    if tracker_config.delay > 0:
+    if tracker_config.announce_delay > 0:
         logger.debug("%s: Waiting %s seconds to notify %s",
-                tracker_config.short_name, tracker_config.delay, announcement.torrent_name)
-        await asyncio.sleep(tracker_config.delay)
+                tracker_config.short_name, tracker_config.announce_delay, announcement.torrent_name)
+        await asyncio.sleep(tracker_config.announce_delay)
 
     db.Announced(date=datetime.datetime.now(), title=announcement.torrent_name,
             indexer=tracker_config.short_name, torrent=announcement.torrent_url, backend=backends_string)

--- a/src/message_handler.py
+++ b/src/message_handler.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("MESSAGE_HANDLER")
 
 def _is_announcement(source, target, tracker_config):
     return (source in tracker_config.announcer_names and
-        target == tracker_config.irc_channel)
+        target in tracker_config.irc_channels)
 
 def _sanitize_message(message):
     message = utils.strip_irc_color_codes(message)

--- a/src/message_handler.py
+++ b/src/message_handler.py
@@ -14,7 +14,7 @@ from tracker_config import VarType
 logger = logging.getLogger("MESSAGE_HANDLER")
 
 def _is_announcement(source, target, tracker_config):
-    return (source == tracker_config.announcer_name and
+    return (source in tracker_config.announcer_names and
         target == tracker_config.irc_channel)
 
 def _sanitize_message(message):

--- a/src/tracker_config.py
+++ b/src/tracker_config.py
@@ -82,7 +82,7 @@ class TrackerXmlConfig:
             for pattern in self.line_patterns:
                 print('\t\t', pattern.regex)
                 for group in pattern.groups:
-                    print('\t\t\þ', group)
+                    print('\t\t\t', group)
             print("\tMultiLinePattern")
             for pattern in self.multiline_patterns:
                 print('\t\t', pattern.regex)
@@ -192,32 +192,32 @@ class TrackerConfig:
         return self._user_config["irc_port"]
 
     @property
-    def irc_nick(self):
-        return self._user_config["nick"] if "nick" in self._user_config else None
+    def irc_nickname(self):
+        return self._user_config["irc_nickname"]
 
     @property
     def irc_tls(self):
-        return self._user_config["tls"]
+        return self._user_config["irc_tls"]
 
     @property
     def irc_tls_verify(self):
-        return self._user_config["tls_verify"]
+        return self._user_config["irc_tls_verify"]
 
     @property
-    def nick_pass(self):
-        return self._user_config["nick_pass"]
+    def irc_ident_password(self):
+        return self._user_config["irc_ident_password"]
 
     @property
-    def inviter(self):
-        return self._user_config["inviter"]
+    def irc_inviter(self):
+        return self._user_config["irc_inviter"]
 
     @property
-    def invite_cmd(self):
-        return self._user_config["invite_cmd"]
+    def irc_invite_cmd(self):
+        return self._user_config["irc_invite_cmd"]
 
     @property
-    def delay(self):
-        return self._user_config["delay"]
+    def announce_delay(self):
+        return self._user_config["announce_delay"]
 
     @property
     def notify_backends(self):

--- a/src/tracker_config.py
+++ b/src/tracker_config.py
@@ -232,8 +232,18 @@ class TrackerConfig:
         return self._xml_config.tracker_info["shortName"]
 
     @property
-    def irc_channel(self):
-        return self._xml_config.servers[0].channels[0]
+    def user_channels(self):
+        return [x.strip() for x in self._user_config["irc_channels"].split(',')]
+
+    # Return both channels from XML and user config
+    @property
+    def irc_channels(self):
+        for server in self._xml_config.servers:
+            for channel in server.channels:
+                yield channel
+
+        for channel in self.user_channels:
+            yield channel
 
     @property
     def announcer_names(self):

--- a/src/tracker_config.py
+++ b/src/tracker_config.py
@@ -196,6 +196,10 @@ class TrackerConfig:
         return self._user_config["irc_nickname"]
 
     @property
+    def irc_server(self):
+        return self._user_config["irc_server"]
+
+    @property
     def irc_tls(self):
         return self._user_config["irc_tls"]
 
@@ -226,10 +230,6 @@ class TrackerConfig:
     @property
     def short_name(self):
         return self._xml_config.tracker_info["shortName"]
-
-    @property
-    def irc_server(self):
-        return self._xml_config.servers[0].names[0]
 
     @property
     def irc_channel(self):

--- a/src/tracker_config.py
+++ b/src/tracker_config.py
@@ -11,7 +11,7 @@ from backend import Backend
 logger = logging.getLogger("TRACKER_CONF")
 debug = False
 
-Server = namedtuple('Server', 'names channels announcers')
+Server = namedtuple("Server", "names channels announcers")
 
 def parse_xml_configs(tracker_config_path):
     xml_configs = {}
@@ -40,7 +40,7 @@ class TrackerXmlConfig:
 
         for setting in root.findall("./settings/*"):
             if "description" not in setting.tag:
-                self.settings.append(re.sub('^(gazelle_|cookie_)', '', setting.tag))
+                self.settings.append(re.sub("^(gazelle_|cookie_)", '', setting.tag))
 
         for server in root.findall("./servers/*"):
             self.servers.append(Server(
@@ -59,9 +59,9 @@ class TrackerXmlConfig:
 
         for ignore in root.findall("./parseinfo/ignore/*"):
             self.ignores.append(
-                    (ignore.attrib['value'],
+                    (ignore.attrib["value"],
                      ("expected" not in ignore.attrib or
-                         ignore.attrib['expected'] == "true")))
+                         ignore.attrib["expected"] == "true")))
 
 
         if debug:
@@ -69,28 +69,28 @@ class TrackerXmlConfig:
                 print(info, root.attrib[info])
             print("\tSettings")
             for setting in self.settings:
-                print('\t\t', setting)
+                print("\t\t", setting)
             print("\tServer")
             for server in self.servers:
-                print('\t\tnames:', server.names)
-                print('\t\tchannels', server.channels)
-                print('\t\tannouncers', server.announcers)
+                print("\t\tnames:", server.names)
+                print("\t\tchannels", server.channels)
+                print("\t\tannouncers", server.announcers)
             print("\tTorrentUrl")
             for var in self.torrent_url:
-                print('\t\t', var.varType, ": ", var.name)
+                print("\t\t", var.varType, ": ", var.name)
             print("\tLinePatterns")
             for pattern in self.line_patterns:
-                print('\t\t', pattern.regex)
+                print("\t\t", pattern.regex)
                 for group in pattern.groups:
-                    print('\t\t\t', group)
+                    print("\t\t\t", group)
             print("\tMultiLinePattern")
             for pattern in self.multiline_patterns:
-                print('\t\t', pattern.regex)
+                print("\t\t", pattern.regex)
                 for group in pattern.groups:
-                    print('\t\t\t', group)
+                    print("\t\t\t", group)
             print("\tIgnores")
             for ignore in self.ignores:
-                print('\t\t', ignore)
+                print("\t\t", ignore)
 
         if self.tracker_info is None:
             return False
@@ -107,8 +107,8 @@ class TrackerXmlConfig:
         groups = extract.findall("./vars/*")
         groupList = []
         for group in groups:
-            groupList.append(group.attrib['name'])
-        return Extract(regex[0].attrib['value'], groupList)
+            groupList.append(group.attrib["name"])
+        return Extract(regex[0].attrib["value"], groupList)
 
 class VarType(Enum):
     STRING = 1

--- a/src/tracker_config.py
+++ b/src/tracker_config.py
@@ -236,8 +236,10 @@ class TrackerConfig:
         return self._xml_config.servers[0].channels[0]
 
     @property
-    def announcer_name(self):
-        return self._xml_config.servers[0].announcers[0]
+    def announcer_names(self):
+        for server in self._xml_config.servers:
+            for announcer in server.announcers:
+                yield announcer
 
     @property
     def line_patterns(self):


### PR DESCRIPTION
This introduces some changes to the user configuration file.

Field name changes:
`nick`             -> `irc_nickname`
`nick_pass`   -> `irc_ident_password`
`tls`                -> `irc_tls`
`tls_verify`    -> `irc_tls_verify`
`inviter`         -> `irc_inviter`
`invite_cmd` -> `irc_invite_cmd`
`delay`           -> `announce_delay`

`irc_port` is now mandatory.

Mandatory fields `irc_server` and  `irc_channels` are added.

`irc_channels` is a comma separated list of channels which will be joined on startup unless invite command has been configured.

Invites to, and announcements from channels in the `irc_channels` list or the channels listed in the tracker XML files will be accepted. Announcements must be sent by one of the announcer names in the tracker XML file.
